### PR TITLE
BVH for SDF ray marching example video

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,9 @@ https://github.com/markusmoenig/Signed
 
 ## Demos
 
+Bounding Volume Hierarchy (BVH) implementation for SDFs to reduce per ray distance measurements
+https://youtu.be/2T2FqvtXqLw
+
 SDF / Ray Marching Prototypes. A collection of SDF related examples using fungi to handle the rendering.
 https://sketchpunk.bitbucket.io/
 


### PR DESCRIPTION
Found this youtube video showing how a BVH can be used to reduce per ray distance calculations significantly, thought it should be part of this resource list.